### PR TITLE
Fix settings page in Drupal 11

### DIFF
--- a/src/Form/RandomFrontpageSettings.php
+++ b/src/Form/RandomFrontpageSettings.php
@@ -5,6 +5,7 @@ namespace Drupal\random_frontpage\Form;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 
@@ -46,8 +47,9 @@ class RandomFrontpageSettings extends ConfigFormBase {
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typedConfigManager,
     EntityDisplayRepositoryInterface $entityDisplayRepository) {
-    parent::__construct($config_factory);
+    parent::__construct($config_factory, $typedConfigManager);
     $this->entityDisplayRepository = $entityDisplayRepository;
   }
 
@@ -63,6 +65,7 @@ class RandomFrontpageSettings extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('entity_display.repository'),
     );
   }


### PR DESCRIPTION
In Drupal 11 the ConfigFormBase constructor requires a $typedConfigManager argument (https://www.drupal.org/node/3404140).